### PR TITLE
Add failing test for Vary

### DIFF
--- a/roundtripper_test.go
+++ b/roundtripper_test.go
@@ -701,7 +701,7 @@ func TestRoundTripper_Vary(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	rt := NewTransport("memcache://?appname=TestRoundTripper_Vary")
+	rt := NewTransport("memcache://")
 	for i, tc := range []struct {
 		lang   string
 		result string


### PR DESCRIPTION
This vary implementation doesn't appear to be caching items correctly.

```bash
> go test -run=.*Vary
--- FAIL: TestRoundTripper_Vary (0.01s)
    roundtripper_test.go:721: assert failed: [assertEqual failed: expected %v, got %v, %s HIT MISS [%!s(int=1)]]
    roundtripper_test.go:721: assert failed: [assertEqual failed: expected %v, got %v, %s HIT MISS [%!s(int=3)]]
    roundtripper_test.go:721: assert failed: [assertEqual failed: expected %v, got %v, %s HIT MISS [%!s(int=4)]]
    roundtripper_test.go:721: assert failed: [assertEqual failed: expected %v, got %v, %s HIT MISS [%!s(int=5)]]
FAIL
exit status 1
FAIL    github.com/bartventer/httpcache 0.009s
```