### PR TITLE
refactor(urlkey): rename `FromURL` to `Normalize`

### DIFF
--- a/internal/urlkeyer.go
+++ b/internal/urlkeyer.go
@@ -32,4 +32,4 @@ func (f URLKeyerFunc) URLKey(u *url.URL) string {
 	return f(u)
 }
 
-func NewURLKeyer() URLKeyer { return URLKeyerFunc(urlkey.FromURL) }
+func NewURLKeyer() URLKeyer { return URLKeyerFunc(urlkey.Normalize) }

--- a/pkg/urlkey/example_test.go
+++ b/pkg/urlkey/example_test.go
@@ -21,14 +21,14 @@ import (
 	"github.com/bartventer/httpcache/pkg/urlkey"
 )
 
-func ExampleFromURL() {
+func ExampleNormalize() {
 	u, err := url.Parse(
 		"https://example.com:8443/abc?query=param&another=value#fragment=part1&part2",
 	)
 	if err != nil {
 		panic(err)
 	}
-	key := urlkey.FromURL(u)
+	key := urlkey.Normalize(u)
 	fmt.Println(key)
 	// Output:
 	// https://example.com:8443/abc?query=param&another=value

--- a/pkg/urlkey/urlkey.go
+++ b/pkg/urlkey/urlkey.go
@@ -31,13 +31,13 @@ import (
 	"github.com/bartventer/httpcache/internal/urlutil"
 )
 
-// FromURL returns a normalized URL string suitable for use as a cache key.
+// Normalize returns a normalized URL string suitable for use as a cache key.
 //
 // It normalizes scheme/host case, default ports, dot-segments, and
 // percent-encoding (for path and query), and excludes fragments.
 //
 // For opaque URLs (u.Opaque != ""), the opaque value is returned unchanged.
-func FromURL(u *url.URL) string {
+func Normalize(u *url.URL) string {
 	if u.Opaque != "" {
 		return u.Opaque
 	}

--- a/pkg/urlkey/urlkey_test.go
+++ b/pkg/urlkey/urlkey_test.go
@@ -80,6 +80,6 @@ func TestFromURL(t *testing.T) {
 			t.Errorf("url.Parse(%q) failed: %v", tt.raw, err)
 			continue
 		}
-		testutil.AssertEqual(t, FromURL(u), tt.expected, "FromURL(%q)", tt.raw)
+		testutil.AssertEqual(t, Normalize(u), tt.expected, "FromURL(%q)", tt.raw)
 	}
 }


### PR DESCRIPTION
* Also updates related examples and tests.
